### PR TITLE
fix: Fixed overlay depth manipullation in the HandleShader. Resolves issues with excessive clipping on overlay geoms.

### DIFF
--- a/src/Handles/Shaders/HandleGeomDataShader.js
+++ b/src/Handles/Shaders/HandleGeomDataShader.js
@@ -58,7 +58,7 @@ void main(void) {
   gl_Position = projectionMatrix * viewPos;
 
   if(Overlay > 0.0){
-    gl_Position.z = mix(gl_Position.z, -1.0, Overlay);
+    gl_Position.z = mix(gl_Position.z, -gl_Position.w, Overlay);
   }
 
   v_viewPos = -viewPos.xyz;

--- a/src/Handles/Shaders/HandleShader.js
+++ b/src/Handles/Shaders/HandleShader.js
@@ -62,7 +62,7 @@ void main(void) {
   gl_Position = projectionMatrix * viewPos;
 
   if(Overlay > 0.0){
-    gl_Position.z = mix(gl_Position.z, -1.0, Overlay);
+    gl_Position.z = mix(gl_Position.z, -gl_Position.w, Overlay);
   }
 
   v_viewPos = viewPos.xyz;


### PR DESCRIPTION
The math in this fix is difficult to explain. I found this fix while searching Google for issues to do with clipping.
So far, it seems to work very well.