### PR TITLE
fix: SelectionTool no longer filters its self based on the 'Alt' key.

### DIFF
--- a/src/Tools/SelectionTool.ts
+++ b/src/Tools/SelectionTool.ts
@@ -140,7 +140,7 @@ class SelectionTool extends BaseTool {
    * @return {boolean} The return value.
    */
   onPointerDown(event: ZeaPointerEvent): void {
-    if (event instanceof ZeaTouchEvent || (event instanceof ZeaMouseEvent && event.button == 0 && !event.altKey)) {
+    if (event instanceof ZeaTouchEvent || (event instanceof ZeaMouseEvent && event.button == 0)) {
       this.pointerDownPos = event.pointerPos
       this.dragging = false
 

--- a/testing-e2e/selection-manager.html
+++ b/testing-e2e/selection-manager.html
@@ -107,11 +107,13 @@
         const setToolToSelectionTool = () => {
           renderer.getViewport().setManipulator(selectionTool)
           selectionOn = true
+          $selectionCheckbox.checked = selectionOn
         }
 
         const setToolToCameraManipulator = () => {
           renderer.getViewport().setManipulator(cameraManipulator)
           selectionOn = false
+          $selectionCheckbox.checked = selectionOn
         }
 
         renderer.getViewport().on('pointerDown', (event) => {
@@ -125,12 +127,8 @@
         })
         document.addEventListener('keydown', (e) => {
           switch (e.key) {
-            case 'b':
-              if (selectionOn) {
-                setToolToCameraManipulator()
-                return
-              }
-              setToolToSelectionTool()
+            case 'Alt':
+              if (!selectionOn) setToolToSelectionTool()
               break
             case 'z':
               if (e.ctrlKey) {
@@ -141,6 +139,13 @@
               if (e.ctrlKey) {
                 UndoRedoManager.getInstance().redo()
               }
+              break
+          }
+        })
+        document.addEventListener('keyup', (e) => {
+          switch (e.key) {
+            case 'Alt':
+              if (selectionOn) setToolToCameraManipulator()
               break
           }
         })


### PR DESCRIPTION
 - client applications now decide what hotkeys manage the tools.