### PR TITLE
fix: AxialRotationHandle now correctly handles rotating objects

### DIFF
--- a/src/Handles/AxialRotationHandle.ts
+++ b/src/Handles/AxialRotationHandle.ts
@@ -20,8 +20,7 @@ import './Shaders/HandleShader'
  */
 class AxialRotationHandle extends BaseAxialRotationHandle {
   radiusParam: NumberParameter
-  handleMat: Material
-  handleXfo: Xfo
+  private handleMat: Material
   handle: GeomItem
   /**
    * Create an axial rotation scene widget.
@@ -46,7 +45,6 @@ class AxialRotationHandle extends BaseAxialRotationHandle {
     // const handleGeom = new Cylinder(radius, thickness * 2, 64, 2, false);
     const handleGeom = new Torus(thickness, radius, 64, Math.PI * 0.5)
     this.handle = new GeomItem('handle', handleGeom, this.handleMat)
-    this.handleXfo = new Xfo()
 
     this.radiusParam.on('valueChanged', () => {
       radius = this.radiusParam.getValue()

--- a/src/Handles/Handle.ts
+++ b/src/Handles/Handle.ts
@@ -282,8 +282,12 @@ class Handle extends TreeItem {
     console.warn('@Handle#onDragEnd - Implement me!', event)
   }
 
-  // TODO:(check) added this method since we check for type Handle and call this method in XfoHandle.ts
-  setTargetParam(param: Parameter<unknown>, track: boolean): void {
+  /**
+   * Sets the taget parameter for manipulation
+   *
+   * @param param - The parameter that will be modified during manipulation
+   */
+  setTargetParam(param: Parameter<unknown>): void {
     console.warn('setTargetParam not implemented')
   }
 }

--- a/src/Handles/Handle.ts
+++ b/src/Handles/Handle.ts
@@ -283,7 +283,7 @@ class Handle extends TreeItem {
   }
 
   /**
-   * Sets the taget parameter for manipulation
+   * Sets the target parameter for manipulation
    *
    * @param param - The parameter that will be modified during manipulation
    */

--- a/src/Handles/LinearMovementHandle.ts
+++ b/src/Handles/LinearMovementHandle.ts
@@ -24,11 +24,11 @@ import { Change } from '..'
  * @extends BaseLinearMovementHandle
  */
 class LinearMovementHandle extends BaseLinearMovementHandle {
-  param: Parameter<unknown>
-  handleMat: Material
-  baseXfo: Xfo
-  change: Change
+  private handleMat: Material
+  private baseXfo: Xfo
+  private change: Change
 
+  param: XfoParameter
   selectionGroup: SelectionGroup
   /**
    * Create a linear movement scene widget.
@@ -59,7 +59,7 @@ class LinearMovementHandle extends BaseLinearMovementHandle {
     transformVertices(tipGeom, tipXfo)
 
     this.colorParam.on('valueChanged', () => {
-      this.handleMat.getParameter('BaseColor').value = this.colorParam.getValue()
+      this.handleMat.getParameter('BaseColor').value = this.colorParam.value
     })
 
     this.addChild(handle)
@@ -71,7 +71,7 @@ class LinearMovementHandle extends BaseLinearMovementHandle {
    */
   highlight(): void {
     super.highlight()
-    this.handleMat.getParameter('BaseColor').value = this.highlightColorParam.getValue()
+    this.handleMat.getParameter('BaseColor').value = this.highlightColorParam.value
   }
 
   /**
@@ -79,7 +79,7 @@ class LinearMovementHandle extends BaseLinearMovementHandle {
    */
   unhighlight(): void {
     super.unhighlight()
-    this.handleMat.getParameter('BaseColor').value = this.colorParam.getValue()
+    this.handleMat.getParameter('BaseColor').value = this.colorParam.value
   }
 
   /**
@@ -92,20 +92,13 @@ class LinearMovementHandle extends BaseLinearMovementHandle {
   }
 
   /**
-   * Sets global xfo target parameter.
+   * Sets the target parameter for this manipulator.
+   * This parameter will be modified by interactions on the manipulator.
    *
-   * @param param - The video param.
-   * @param track - The track param.
+   * @param param - The parameter that will be modified during manipulation
    */
-  setTargetParam(param: Parameter<any>, track = true): void {
+  setTargetParam(param: Parameter<any>): void {
     this.param = param
-    if (track) {
-      const __updateGizmo = () => {
-        this.globalXfoParam.value = param.getValue()
-      }
-      __updateGizmo()
-      param.on('valueChanged', __updateGizmo)
-    }
   }
 
   /**
@@ -113,7 +106,7 @@ class LinearMovementHandle extends BaseLinearMovementHandle {
    *
    * @return - returns handle's target global Xfo.
    */
-  getTargetParam(): XfoParameter | Parameter<unknown> {
+  getTargetParam(): XfoParameter {
     return this.param ? this.param : this.globalXfoParam
   }
 
@@ -123,8 +116,8 @@ class LinearMovementHandle extends BaseLinearMovementHandle {
    * @param event - The event param.
    */
   onDragStart(event: ZeaPointerEvent): void {
-    const param = this.getTargetParam()
-    this.baseXfo = <Xfo>param.getValue()
+    const param = this.getTargetParam() as XfoParameter
+    this.baseXfo = param.value
 
     if (this.selectionGroup) {
       const items = this.selectionGroup.getItems()

--- a/src/Handles/LinearScaleHandle.ts
+++ b/src/Handles/LinearScaleHandle.ts
@@ -24,13 +24,15 @@ import SelectionXfoChange from '../UndoRedo/Changes/SelectionXfoChange'
  * @extends BaseLinearMovementHandle
  */
 class LinearScaleHandle extends BaseLinearMovementHandle {
+  private handleMat: Material
+  private oriXfo: Xfo
+  private tmplocalXfo: Xfo
+  private baseXfo: Xfo
+  private change: Change
+
   param: Parameter<unknown>
-  handleMat: Material
-  oriXfo: Xfo
-  tmplocalXfo: Xfo
-  baseXfo: Xfo
-  change: Change
   selectionGroup: SelectionGroup
+
   /**
    * Create a linear scale scene widget.
    *
@@ -98,18 +100,10 @@ class LinearScaleHandle extends BaseLinearMovementHandle {
   /**
    * Sets global xfo target parameter.
    *
-   * @param param - The video param.
-   * @param track - The track param.
+   * @param param - The parameter that will be modified during manipulation
    */
-  setTargetParam(param: XfoParameter, track = true): void {
+  setTargetParam(param: XfoParameter): void {
     this.param = param
-    if (track) {
-      const __updateGizmo = () => {
-        this.globalXfoParam.value = param.getValue()
-      }
-      __updateGizmo()
-      param.on('valueChanged', __updateGizmo)
-    }
   }
 
   /**

--- a/src/Handles/PlanarMovementHandle.ts
+++ b/src/Handles/PlanarMovementHandle.ts
@@ -1,7 +1,7 @@
 import Handle from './Handle'
 import ParameterValueChange from '../UndoRedo/Changes/ParameterValueChange'
 import UndoRedoManager from '../UndoRedo/UndoRedoManager'
-import { Parameter, Vec3, Xfo, ZeaPointerEvent, XRControllerEvent } from '@zeainc/zea-engine'
+import { Parameter, Vec3, Xfo, ZeaPointerEvent, XRControllerEvent, XfoParameter } from '@zeainc/zea-engine'
 import { Change } from '..'
 import SelectionGroup from '../SelectionGroup'
 import SelectionXfoChange from '../UndoRedo/Changes/SelectionXfoChange'
@@ -13,10 +13,10 @@ import SelectionXfoChange from '../UndoRedo/Changes/SelectionXfoChange'
  */
 class PlanarMovementHandle extends Handle {
   param: Parameter<unknown>
-  fullXfoManipulationInVR: boolean
-  grabOffset: Vec3
-  baseXfo: Xfo
-  change: Change
+  private fullXfoManipulationInVR: boolean
+  private grabOffset: Vec3
+  private baseXfo: Xfo
+  private change: Change
   selectionGroup: SelectionGroup
 
   /**
@@ -41,18 +41,10 @@ class PlanarMovementHandle extends Handle {
   /**
    * Sets global xfo target parameter.
    *
-   * @param param - The video param.
-   * @param track - The track param.
+   * @param param - The parameter that will be modified during manipulation
    */
-  setTargetParam(param: any, track = true): void {
+  setTargetParam(param: XfoParameter): void {
     this.param = param
-    if (track) {
-      const __updateGizmo = () => {
-        this.globalXfoParam.value = param.getValue()
-      }
-      __updateGizmo()
-      param.on('valueChanged', __updateGizmo)
-    }
   }
 
   /**

--- a/src/Handles/ScreenSpaceMovementHandle.ts
+++ b/src/Handles/ScreenSpaceMovementHandle.ts
@@ -1,4 +1,4 @@
-import { Parameter, Ray, Xfo, ZeaPointerEvent, ZeaMouseEvent, GLViewport } from '@zeainc/zea-engine'
+import { Parameter, Ray, Xfo, ZeaPointerEvent, ZeaMouseEvent, GLViewport, XfoParameter } from '@zeainc/zea-engine'
 import Handle from './Handle.js'
 import ParameterValueChange from '../UndoRedo/Changes/ParameterValueChange.js'
 import UndoRedoManager from '../UndoRedo/UndoRedoManager.js'
@@ -14,7 +14,7 @@ import SelectionGroup from '../SelectionGroup.js'
  * @extends Handle
  */
 class ScreenSpaceMovementHandle extends Handle {
-  param: Parameter<unknown>
+  param: XfoParameter
   baseXfo: Xfo
   change: Change
   selectionGroup: SelectionGroup
@@ -39,18 +39,10 @@ class ScreenSpaceMovementHandle extends Handle {
   /**
    * Sets global xfo target parameter.
    *
-   * @param param - The video param.
-   * @param track - The track param.
+   * @param param - The parameter that will be modified during manipulation
    */
-  setTargetParam(param: any, track = true): void {
+  setTargetParam(param: XfoParameter): void {
     this.param = param
-    if (track) {
-      const __updateGizmo = () => {
-        this.globalXfoParam.value = param.getValue()
-      }
-      __updateGizmo()
-      param.on('valueChanged', __updateGizmo)
-    }
   }
 
   /**
@@ -58,7 +50,7 @@ class ScreenSpaceMovementHandle extends Handle {
    *
    * @return {Parameter} - returns handle's target global Xfo.
    */
-  getTargetParam(): Parameter<unknown> {
+  getTargetParam(): XfoParameter {
     return this.param ? this.param : this.globalXfoParam
   }
 

--- a/src/Handles/SliderHandle.ts
+++ b/src/Handles/SliderHandle.ts
@@ -114,8 +114,7 @@ class SliderHandle extends BaseLinearMovementHandle {
   /**
    * Sets global xfo target parameter.
    *
-   * @param param - The video param.
-   * @param track - The track param.
+   * @param param - The parameter that will be modified during manipulation
    */
   setTargetParam(param: Parameter<unknown>): void {
     this.param = param

--- a/src/Handles/SphericalRotationHandle.ts
+++ b/src/Handles/SphericalRotationHandle.ts
@@ -23,7 +23,7 @@ import { ParameterValueChange } from '../UndoRedo/Changes/ParameterValueChange'
  * @extends Handle
  */
 class SphericalRotationHandle extends Handle {
-  param: Parameter<unknown>
+  param: XfoParameter
   radius: number
   vec0: Vec3
   baseXfo: Xfo
@@ -63,18 +63,10 @@ class SphericalRotationHandle extends Handle {
   /**
    * Sets global xfo target parameter.
    *
-   * @param param - The video param.
-   * @param track - The track param.
+   * @param param - The parameter that will be modified during manipulation
    */
-  setTargetParam(param: XfoParameter, track = true): void {
+  setTargetParam(param: XfoParameter): void {
     this.param = param
-    if (track) {
-      const __updateGizmo = () => {
-        this.globalXfoParam.value = param.getValue()
-      }
-      __updateGizmo()
-      param.on('valueChanged', __updateGizmo)
-    }
   }
 
   /**

--- a/src/Handles/XfoHandle.ts
+++ b/src/Handles/XfoHandle.ts
@@ -180,12 +180,18 @@ class XfoHandle extends TreeItem {
   /**
    * Sets global xfo target parameter.
    *
-   * @param param - The video param.
+   * @param param - The parameter that will be modified during manipulation
    */
-  setTargetParam(param: Parameter<unknown>, track = true): void {
+  setTargetParam(param: XfoParameter): void {
     this.param = param
     this.traverse((item) => {
-      if (item instanceof Handle) item.setTargetParam(param, false) // TODO: should this take track?
+      if (
+        item instanceof LinearMovementHandle ||
+        item instanceof XfoPlanarMovementHandle ||
+        item instanceof AxialRotationHandle
+      ) {
+        item.setTargetParam(param)
+      }
     })
   }
 
@@ -201,7 +207,7 @@ class XfoHandle extends TreeItem {
         item instanceof XfoPlanarMovementHandle ||
         item instanceof AxialRotationHandle
       ) {
-        item.setSelectionGroup(selectionGroup) // TODO: should this take track?
+        item.setSelectionGroup(selectionGroup)
       }
     })
   }

--- a/src/UndoRedo/Changes/ParameterValueChange.ts
+++ b/src/UndoRedo/Changes/ParameterValueChange.ts
@@ -17,7 +17,7 @@ class ParameterValueChange extends Change {
   /**
    * Creates an instance of ParameterValueChange.
    *
-   * @param param - The param value.
+   * @param param - The Parameter object that is modified by this change.
    * @param newValue - The newValue value.
    */
   constructor(param?: Parameter<unknown>, newValue?: any) {

--- a/src/UndoRedo/Changes/SelectionXfoChange.ts
+++ b/src/UndoRedo/Changes/SelectionXfoChange.ts
@@ -19,7 +19,7 @@ class SelectionXfoChange extends Change {
   /**
    * Creates an instance of SelectionXfoChange.
    *
-   * @param param - The param value.
+   * @param param - The Parameter object that is modified by this change.
    * @param newValue - The newValue value.
    */
   constructor(treeItems: TreeItem[], baseXfo: Xfo) {

--- a/testing-e2e/axial-rotation-handle.html
+++ b/testing-e2e/axial-rotation-handle.html
@@ -34,6 +34,8 @@
         GeomItem,
         NumberParameter,
         TreeItem,
+        CADAsset,
+        AssetLoadContext
       } = window.zeaEngine
       const { AxialRotationHandle } = window.zeaUx
       const domElement = document.getElementById('canvas')
@@ -46,40 +48,36 @@
       renderer.getViewport().backgroundColorParam.value = color
       renderer.setScene(scene)
 
-      const treeItem1 = new TreeItem('TranslateTarget')
-      scene.getRoot().addChild(treeItem1)
+      
+      const cadAsset = new CADAsset()
+      const context = new AssetLoadContext()
+      const url = 'data/zcad/3.9.1/Dead_eye_bearing.stp.zcad'
+      cadAsset.localXfoParam.value.sc.set(10, 10, 10)
+      cadAsset.load(url, context).then(() => {
+        // renderer.frameAll()
+      })
+      scene.getRoot().addChild(cadAsset)
+
+      const widgets = new TreeItem('Widgets')
+      scene.getRoot().addChild(widgets)
+
       const widget1 = new AxialRotationHandle('axial1', 0.2, 0.007, new Color('#6600FF'))
-      widget1.getParameter('HighlightColor').setValue(new Color(1, 0.5, 1))
+      widget1.highlightColorParam.setValue(new Color(1, 0.5, 1))
       const xfo1 = new Xfo()
       xfo1.ori.setFromAxisAndAngle(new Vec3(0, 1, 0), Math.PI * 0.5)
-      widget1.getParameter('LocalXfo').setValue(xfo1)
+      widget1.localXfoParam.setValue(xfo1)
+      widgets.addChild(widget1)
 
-      const handleGeom1 = new Cuboid(0.5, 0.5, 0.5)
-      const material1 = new Material('handle', 'SimpleSurfaceShader')
-      material1.getParameter('BaseColor').setValue(new Color(89 / 255, 182 / 255, 92 / 255))
-      const geomItem1 = new GeomItem('handle', handleGeom1, material1)
-      widget1.addChild(geomItem1)
 
-      treeItem1.addChild(widget1)
-
-      const treeItem2 = new TreeItem('TranslateTarget')
-      scene.getRoot().addChild(treeItem2)
       const widget2 = new AxialRotationHandle('axial2', 0.15, 0.004)
       widget2.getParameter('Color').setValue(new Color('#AA1122'))
+      widgets.addChild(widget2)
 
-      const xfo2 = new Xfo()
-      xfo2.ori.setFromAxisAndAngle(new Vec3(1, 0, 0), Math.PI * 0.5)
-      widget2.getParameter('LocalXfo').setValue(xfo2)
 
-      const handleGeom2 = new Cuboid(0.6, 0.8, 0.7)
-      const material2 = new Material('handle', 'SimpleSurfaceShader')
-      material2.getParameter('BaseColor').setValue(new Color('#5522AA'))
-      const geomItem2 = new GeomItem('handle', handleGeom2, material2)
-      widget2.addChild(geomItem2)
-      treeItem2.addChild(widget2)
-
-      const translateXfo1 = new Xfo(new Vec3(2, 0, 0))
-      treeItem2.getParameter('GlobalXfo').setValue(translateXfo1)
+      // Note: Set 'track' to false, we as we add the widgets to the asset 
+      widget1.setTargetParam(cadAsset.globalXfoParam, false)
+      widget2.setTargetParam(cadAsset.globalXfoParam, false)
+      scene.getRoot().addChild(widgets)
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(3, 5, 2), new Vec3(1, 0, 0))
 

--- a/testing-e2e/axial-rotation-handle.html
+++ b/testing-e2e/axial-rotation-handle.html
@@ -73,11 +73,10 @@
       widget2.getParameter('Color').setValue(new Color('#AA1122'))
       widgets.addChild(widget2)
 
-
-      // Note: Set 'track' to false, we as we add the widgets to the asset 
-      widget1.setTargetParam(cadAsset.globalXfoParam, false)
-      widget2.setTargetParam(cadAsset.globalXfoParam, false)
-      scene.getRoot().addChild(widgets)
+      // Now connect both widgets to the CADAsset.
+      widget1.setTargetParam(cadAsset.globalXfoParam)
+      widget2.setTargetParam(cadAsset.globalXfoParam)
+      cadAsset.addChild(widgets)
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(3, 5, 2), new Vec3(1, 0, 0))
 


### PR DESCRIPTION
fix: AxialRotationHandle now correctly handles rotating objects around arbitrary axes, when not connected to the selection manager.

 - simplified the Handles overall.