### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/ZeaInc/zea-ux.git"
+    "url": "git+https://github.com/ZeaInc/zea-ux.git"
   },
   "bugs": {
     "url": "https://github.com/ZeaInc/zea-ux/issues"


### PR DESCRIPTION
## Summary

- replace the SSH repository URL with a public HTTPS URL
- let package tooling and consumers resolve the source without GitHub SSH credentials

This is a metadata-only change with no runtime code, dependency, or lockfile changes.

## Validation

- direct package metadata assertion
- `pnpm pack --dry-run --json --config.ignore-scripts=true`
- `git diff --check`

## Environment note

The lockfile references private GitHub Packages artifact `@zeainc/zea-engine@4.21.0-7683720`, which requires repository credentials and returns HTTP 401 in this environment. I used the public `4.17.0` package only for a best-effort local check, but it is API-incompatible with the current source. The existing lint command also reports seven JSDoc errors in `src/Tools/VRTools/dom-to-image.js`. No dependency, source, generated file, or lockfile is changed in this PR.